### PR TITLE
update base repo to reflect repo name change

### DIFF
--- a/spam.js
+++ b/spam.js
@@ -34,7 +34,7 @@ prompt.get([{
   // Always star THIS repo!
   github.repos.star({
     user: 'alexanderGugel',
-    repo: 'spam-me'
+    repo: 'follow-me'
   });
 
   // Follow all org members


### PR DESCRIPTION
The code still has the old repo name 'spam-me' hardcoded into it in the `// Always star THIS repo!` section. This updates that.
